### PR TITLE
Frontend/calendar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -275,20 +275,49 @@ const ActiveProjectPageWrapper: React.FC = () => {
 
 const RecordCalendarPageWrapper: React.FC = () => {
   const navigate = useNavigate();
-  const { activeProjects, records, schedules } = useApp();
+  const { activeProjects, records, schedules, addRecord } = useApp();
 
   const handleBack = () => {
     navigate('/dashboard');
   };
 
   const handleAddRecord = (record: Partial<Record>) => {
-    // TODO: 記録追加のロジックを実装
-    console.log('Add record:', record);
+    // AppContextの addRecord メソッドを使用して記録を追加
+    addRecord(record);
+
+    // 成功メッセージを表示（将来的にはtoast通知などで置き換え）
+    console.log('記録が正常に追加されました:', {
+      title: record.title,
+      type: record.recordType,
+      date: new Date(record.recordDate || '').toLocaleDateString('ja-JP')
+    });
   };
 
   const handleViewRecord = (record: Record) => {
-    // TODO: 記録詳細表示のロジックを実装
-    console.log('View record:', record);
+    // 記録詳細を表示（将来的にはモーダルや詳細ページで表示）
+    const recordDetails = {
+      id: record.id,
+      title: record.title,
+      type: record.recordType,
+      content: record.content,
+      date: new Date(record.recordDate).toLocaleDateString('ja-JP', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long'
+      }),
+      time: new Date(record.recordDate).toLocaleTimeString('ja-JP', {
+        hour: '2-digit',
+        minute: '2-digit'
+      }),
+      projectId: record.projectId,
+      data: record.data
+    };
+
+    console.log('記録詳細:', recordDetails);
+
+    // 将来的にはここで詳細表示モーダルを開く
+    // 例: setSelectedRecord(record); setShowRecordDetailModal(true);
   };
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import RecordCalendarPage from './pages/RecordCalendarPage';
 
 import { generateMockThemes } from './utils/mockThemeGenerator';
 import { mockUserStats, mockRecentAchievements } from './utils/mockData';
+import { Record } from './types';
 import './styles/Common.css';
 
 // ページコンポーネントをラップしてReact Router対応にする
@@ -280,12 +281,12 @@ const RecordCalendarPageWrapper: React.FC = () => {
     navigate('/dashboard');
   };
 
-  const handleAddRecord = (record: any) => {
+  const handleAddRecord = (record: Partial<Record>) => {
     // TODO: 記録追加のロジックを実装
     console.log('Add record:', record);
   };
 
-  const handleViewRecord = (record: any) => {
+  const handleViewRecord = (record: Record) => {
     // TODO: 記録詳細表示のロジックを実装
     console.log('View record:', record);
   };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,7 @@ import RecordCalendarPage from './pages/RecordCalendarPage';
 
 import { generateMockThemes } from './utils/mockThemeGenerator';
 import { mockUserStats, mockRecentAchievements } from './utils/mockData';
-import { Record } from './types';
+import type { Record, UserProfile, ResearchProject, ResearchTheme, UserStats, Achievement } from './types';
 import './styles/Common.css';
 
 // ページコンポーネントをラップしてReact Router対応にする

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import ThemeSelectorPage from './pages/ThemeSelectorPage';
 import ThemeResultsPage from './pages/ThemeResultsPage';
 import SelectedThemePage from './pages/SelectedThemePage';
 import ActiveProjectPage from './pages/ActiveProjectPage';
+import RecordCalendarPage from './pages/RecordCalendarPage';
 
 import { generateMockThemes } from './utils/mockThemeGenerator';
 import { mockUserStats, mockRecentAchievements } from './utils/mockData';
@@ -120,8 +121,7 @@ const DashboardPageWrapper: React.FC = () => {
   };
 
   const handleViewRecords = () => {
-    console.log('View records');
-    // TODO: 記録一覧画面に遷移
+    navigate('/records');
   };
 
   const handleViewLearning = () => {
@@ -272,6 +272,36 @@ const ActiveProjectPageWrapper: React.FC = () => {
   );
 };
 
+const RecordCalendarPageWrapper: React.FC = () => {
+  const navigate = useNavigate();
+  const { activeProjects, records, schedules } = useApp();
+
+  const handleBack = () => {
+    navigate('/dashboard');
+  };
+
+  const handleAddRecord = (record: any) => {
+    // TODO: 記録追加のロジックを実装
+    console.log('Add record:', record);
+  };
+
+  const handleViewRecord = (record: any) => {
+    // TODO: 記録詳細表示のロジックを実装
+    console.log('View record:', record);
+  };
+
+  return (
+    <RecordCalendarPage
+      activeProjects={activeProjects}
+      records={records || []}
+      schedules={schedules || []}
+      onBack={handleBack}
+      onAddRecord={handleAddRecord}
+      onViewRecord={handleViewRecord}
+    />
+  );
+};
+
 // ルーターの設定
 const router = createBrowserRouter([
   {
@@ -313,6 +343,10 @@ const router = createBrowserRouter([
       {
         path: 'project/:id',
         element: <ActiveProjectPageWrapper />,
+      },
+      {
+        path: 'records',
+        element: <RecordCalendarPageWrapper />,
       },
     ],
   },

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -44,6 +44,8 @@ interface AppContextType {
   handleUpdateProjectProgress: (projectId: string, stepIndex: number) => void;
   handleThemeDecision: (theme: ResearchTheme) => void;
   generateTasksForProject: (project: ResearchProject, stepIndex: number) => Array<{ icon: string; task: string; urgent: boolean }>;
+  addRecord: (record: Partial<Record>) => void;
+  updateRecord: (recordId: string, updates: Partial<Record>) => void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -396,6 +398,36 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     setSelectedTheme(null);
   };
 
+  // 記録関連のメソッド
+  const addRecord = (record: Partial<Record>) => {
+    const newRecord: Record = {
+      id: `record-${Date.now()}`,
+      projectId: record.projectId || '',
+      stepId: record.stepId,
+      recordType: record.recordType || 'note',
+      title: record.title || '',
+      content: record.content || '',
+      data: record.data || {},
+      recordDate: record.recordDate || new Date().toISOString(),
+      weatherInfo: record.weatherInfo,
+      locationInfo: record.locationInfo,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+
+    setRecords(prev => [newRecord, ...prev]);
+  };
+
+  const updateRecord = (recordId: string, updates: Partial<Record>) => {
+    setRecords(prev =>
+      prev.map(record =>
+        record.id === recordId
+          ? { ...record, ...updates, updatedAt: new Date().toISOString() }
+          : record
+      )
+    );
+  };
+
   const value: AppContextType = {
     authState,
     authError,
@@ -417,7 +449,9 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     setSelectedProject,
     handleUpdateProjectProgress,
     handleThemeDecision,
-    generateTasksForProject
+    generateTasksForProject,
+    addRecord,
+    updateRecord
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { UserProfile, ResearchTheme, ResearchProject, AuthState, LoginRequest, SignupRequest, User, Grade, Interest, Personality, Strength, Duration } from '../types';
+import { UserProfile, ResearchTheme, ResearchProject, AuthState, LoginRequest, SignupRequest, User, Grade, Interest, Personality, Strength, Duration, Record, Schedule } from '../types';
 import { generateMockThemes } from '../utils/mockThemeGenerator';
-import { mockActiveProjects, mockUserStats, mockRecentAchievements, mockPastProjects } from '../utils/mockData';
+import { mockActiveProjects, mockUserStats, mockRecentAchievements, mockPastProjects, mockRecords, mockSchedules } from '../utils/mockData';
 
 // ヘルパー関数: 研究ジャンルに応じたステップ数を返す
 const getStepCount = (genre: string): number => {
@@ -24,6 +24,10 @@ interface AppContextType {
   pastProjects: ResearchProject[];
   selectedProject: ResearchProject | null;
   todaysTasks: Array<{ icon: string; task: string; urgent: boolean }>;
+
+  // 記録・スケジュール関連
+  records: Record[];
+  schedules: Schedule[];
 
   // テーマ関連
   generatedThemes: ResearchTheme[];
@@ -72,6 +76,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   // プロジェクト状態の管理を追加
   const [activeProjects, setActiveProjects] = useState<ResearchProject[]>(mockActiveProjects);
   const [pastProjects, setPastProjects] = useState<ResearchProject[]>(mockPastProjects);
+  const [records, setRecords] = useState<Record[]>(mockRecords);
+  const [schedules, setSchedules] = useState<Schedule[]>(mockSchedules);
   const [todaysTasks, setTodaysTasks] = useState([
     { icon: '🌱', task: '植物の成長を測定しよう', urgent: true },
     { icon: '📷', task: '実験結果の写真を撮ろう', urgent: false }
@@ -398,6 +404,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
     pastProjects,
     selectedProject,
     todaysTasks,
+    records,
+    schedules,
     generatedThemes,
     selectedTheme,
     handleLogin,

--- a/frontend/src/pages/ActiveProjectPage.tsx
+++ b/frontend/src/pages/ActiveProjectPage.tsx
@@ -308,7 +308,7 @@ const ActiveProjectPage: React.FC<ActiveProjectPageProps> = ({
         </div>
       </div>
 
-      <div className="content-section">
+      <div className="active-project-content">
         <div className="steps-timeline">
           <h2>研究の流れ</h2>
           <div className="timeline">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -175,7 +175,7 @@ const DashboardPage: React.FC<DashboardPageProps> = ({
         </button>
         <button className="quick-action-btn" onClick={onViewRecords}>
           <span className="qa-icon">📝</span>
-          <span className="qa-label">記録</span>
+          <span className="qa-label">記録カレンダー</span>
         </button>
         <button className="quick-action-btn" onClick={onViewLearning}>
           <span className="qa-icon">⚙️</span>

--- a/frontend/src/pages/RecordCalendarPage.tsx
+++ b/frontend/src/pages/RecordCalendarPage.tsx
@@ -148,9 +148,9 @@ const RecordCalendarPage: React.FC<RecordCalendarPageProps> = ({
 
         {/* カレンダーグリッド */}
         <div className="calendar-grid">
-          {calendarDays.map((day, index) => (
-            <div
-              key={index}
+                  {calendarDays.map((day) => (
+          <div
+            key={day.date.toISOString()}
               className={`calendar-day ${!day.isCurrentMonth ? 'other-month' : ''} ${
                 day.hasActions ? 'has-actions' : ''
               } ${day.hasObservations ? 'has-observations' : ''} ${

--- a/frontend/src/pages/RecordCalendarPage.tsx
+++ b/frontend/src/pages/RecordCalendarPage.tsx
@@ -1,0 +1,328 @@
+import React, { useState, useEffect } from 'react';
+import { Record, ResearchProject, Schedule } from '../types';
+import '../styles/RecordCalendar.css';
+import '../styles/Common.css';
+
+interface RecordCalendarPageProps {
+  activeProjects: ResearchProject[];
+  records: Record[];
+  schedules: Schedule[];
+  onBack: () => void;
+  onAddRecord: (record: Partial<Record>) => void;
+  onViewRecord: (record: Record) => void;
+}
+
+interface CalendarDay {
+  date: Date;
+  isCurrentMonth: boolean;
+  hasActions: boolean;
+  hasObservations: boolean;
+  actionCount: number;
+  records: Record[];
+  schedules: Schedule[];
+}
+
+const RecordCalendarPage: React.FC<RecordCalendarPageProps> = ({
+  activeProjects,
+  records,
+  schedules,
+  onBack,
+  onAddRecord,
+  onViewRecord
+}) => {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [showRecordModal, setShowRecordModal] = useState(false);
+  const [newRecordType, setNewRecordType] = useState<'observation' | 'experiment' | 'note'>('observation');
+  const [newRecordContent, setNewRecordContent] = useState('');
+  const [selectedProject, setSelectedProject] = useState<string>('');
+
+  // 月の表示名を取得
+  const getMonthName = (date: Date) => {
+    return date.toLocaleDateString('ja-JP', { year: 'numeric', month: 'long' });
+  };
+
+  // カレンダーの日付データを生成
+  const generateCalendarDays = (): CalendarDay[] => {
+    const year = currentDate.getFullYear();
+    const month = currentDate.getMonth();
+
+    // 月の最初の日と最後の日
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+
+    // カレンダーの開始日（前月の日曜日から）
+    const startDate = new Date(firstDay);
+    startDate.setDate(startDate.getDate() - firstDay.getDay());
+
+    // カレンダーの終了日（翌月の土曜日まで）
+    const endDate = new Date(lastDay);
+    endDate.setDate(endDate.getDate() + (6 - lastDay.getDay()));
+
+    const days: CalendarDay[] = [];
+    const current = new Date(startDate);
+
+    while (current <= endDate) {
+      const dateStr = current.toISOString().split('T')[0];
+      const dayRecords = records.filter(r => r.recordDate.startsWith(dateStr));
+      const daySchedules = schedules.filter(s => s.scheduledAt.startsWith(dateStr));
+
+      days.push({
+        date: new Date(current),
+        isCurrentMonth: current.getMonth() === month,
+        hasActions: dayRecords.length > 0 || daySchedules.some(s => s.isCompleted),
+        hasObservations: dayRecords.some(r => r.recordType === 'observation'),
+        actionCount: dayRecords.length + daySchedules.filter(s => s.isCompleted).length,
+        records: dayRecords,
+        schedules: daySchedules
+      });
+
+      current.setDate(current.getDate() + 1);
+    }
+
+    return days;
+  };
+
+  const calendarDays = generateCalendarDays();
+
+  // 前月・次月の移動
+  const navigateMonth = (direction: 'prev' | 'next') => {
+    const newDate = new Date(currentDate);
+    newDate.setMonth(newDate.getMonth() + (direction === 'prev' ? -1 : 1));
+    setCurrentDate(newDate);
+  };
+
+  // 日付をクリック
+  const handleDateClick = (day: CalendarDay) => {
+    setSelectedDate(day.date);
+  };
+
+  // 記録を追加
+  const handleAddRecord = () => {
+    if (!selectedDate || !selectedProject || !newRecordContent.trim()) return;
+
+    const newRecord: Partial<Record> = {
+      projectId: selectedProject,
+      recordType: newRecordType,
+      title: `${newRecordType === 'observation' ? '観察記録' : newRecordType === 'experiment' ? '実験記録' : 'メモ'}`,
+      content: newRecordContent,
+      recordDate: selectedDate.toISOString(),
+      data: {}
+    };
+
+    onAddRecord(newRecord);
+    setNewRecordContent('');
+    setShowRecordModal(false);
+  };
+
+  // 観察型プロジェクトを取得
+  const observationProjects = activeProjects.filter(p => p.genre === 'observation');
+
+  return (
+    <div className="record-calendar-page">
+      <div className="page-header">
+        <button className="back-btn" onClick={onBack}>
+          ← 戻る
+        </button>
+        <h1 className="page-title">📅 記録カレンダー</h1>
+      </div>
+
+      <div className="calendar-container">
+        {/* カレンダーヘッダー */}
+        <div className="calendar-header">
+          <button className="nav-btn" onClick={() => navigateMonth('prev')}>
+            ‹
+          </button>
+          <h2 className="month-title">{getMonthName(currentDate)}</h2>
+          <button className="nav-btn" onClick={() => navigateMonth('next')}>
+            ›
+          </button>
+        </div>
+
+        {/* 曜日ヘッダー */}
+        <div className="calendar-weekdays">
+          {['日', '月', '火', '水', '木', '金', '土'].map(day => (
+            <div key={day} className="weekday-header">{day}</div>
+          ))}
+        </div>
+
+        {/* カレンダーグリッド */}
+        <div className="calendar-grid">
+          {calendarDays.map((day, index) => (
+            <div
+              key={index}
+              className={`calendar-day ${!day.isCurrentMonth ? 'other-month' : ''} ${
+                day.hasActions ? 'has-actions' : ''
+              } ${day.hasObservations ? 'has-observations' : ''} ${
+                selectedDate?.toDateString() === day.date.toDateString() ? 'selected' : ''
+              }`}
+              onClick={() => handleDateClick(day)}
+            >
+              <div className="day-number">{day.date.getDate()}</div>
+              {day.hasActions && (
+                <div className="activity-indicators">
+                  {day.hasObservations && <div className="observation-dot">🔍</div>}
+                  {day.actionCount > 0 && (
+                    <div className="action-count">{day.actionCount}</div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* 凡例 */}
+        <div className="calendar-legend">
+          <div className="legend-item">
+            <div className="legend-color has-actions-color"></div>
+            <span>アクション実行日</span>
+          </div>
+          <div className="legend-item">
+            <div className="legend-icon">🔍</div>
+            <span>観察記録あり</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 選択した日の詳細 */}
+      {selectedDate && (
+        <div className="selected-date-details">
+          <div className="details-header">
+            <h3>{selectedDate.toLocaleDateString('ja-JP', {
+              month: 'long',
+              day: 'numeric',
+              weekday: 'long'
+            })}</h3>
+            {observationProjects.length > 0 && (
+              <button
+                className="add-record-btn"
+                onClick={() => setShowRecordModal(true)}
+              >
+                + 記録追加
+              </button>
+            )}
+          </div>
+
+          <div className="day-records">
+            {(() => {
+              const dayData = calendarDays.find(d =>
+                d.date.toDateString() === selectedDate.toDateString()
+              );
+
+              if (!dayData || (dayData.records.length === 0 && dayData.schedules.length === 0)) {
+                return <p className="no-records">この日の記録はありません</p>;
+              }
+
+              return (
+                <div className="records-list">
+                  {/* 記録 */}
+                  {dayData.records.map(record => (
+                    <div key={record.id} className="record-item" onClick={() => onViewRecord(record)}>
+                      <div className="record-type-icon">
+                        {record.recordType === 'observation' ? '🔍' :
+                         record.recordType === 'experiment' ? '⚗️' : '📝'}
+                      </div>
+                      <div className="record-content">
+                        <div className="record-title">{record.title}</div>
+                        <div className="record-preview">{record.content.substring(0, 50)}...</div>
+                      </div>
+                      <div className="record-time">
+                        {new Date(record.recordDate).toLocaleTimeString('ja-JP', {
+                          hour: '2-digit',
+                          minute: '2-digit'
+                        })}
+                      </div>
+                    </div>
+                  ))}
+
+                  {/* 完了したスケジュール */}
+                  {dayData.schedules.filter(s => s.isCompleted).map(schedule => (
+                    <div key={schedule.id} className="schedule-item completed">
+                      <div className="schedule-icon">✅</div>
+                      <div className="schedule-content">
+                        <div className="schedule-title">{schedule.title}</div>
+                        <div className="schedule-description">{schedule.description}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              );
+            })()}
+          </div>
+        </div>
+      )}
+
+      {/* 記録追加モーダル */}
+      {showRecordModal && (
+        <div className="modal-overlay" onClick={() => setShowRecordModal(false)}>
+          <div className="record-modal" onClick={e => e.stopPropagation()}>
+            <div className="modal-header">
+              <h3>記録を追加</h3>
+              <button className="close-btn" onClick={() => setShowRecordModal(false)}>
+                ×
+              </button>
+            </div>
+
+            <div className="modal-body">
+              <div className="form-group">
+                <label>プロジェクト</label>
+                <select
+                  value={selectedProject}
+                  onChange={e => setSelectedProject(e.target.value)}
+                >
+                  <option value="">プロジェクトを選択</option>
+                  {observationProjects.map(project => (
+                    <option key={project.id} value={project.id}>
+                      {project.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="form-group">
+                <label>記録の種類</label>
+                <div className="record-type-buttons">
+                  {['observation', 'experiment', 'note'].map(type => (
+                    <button
+                      key={type}
+                      className={`type-btn ${newRecordType === type ? 'active' : ''}`}
+                      onClick={() => setNewRecordType(type as any)}
+                    >
+                      {type === 'observation' ? '🔍 観察' :
+                       type === 'experiment' ? '⚗️ 実験' : '📝 メモ'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="form-group">
+                <label>記録内容</label>
+                <textarea
+                  value={newRecordContent}
+                  onChange={e => setNewRecordContent(e.target.value)}
+                  placeholder="今日の観察や実験の結果を記録しましょう..."
+                  rows={4}
+                />
+              </div>
+            </div>
+
+            <div className="modal-footer">
+              <button className="cancel-btn" onClick={() => setShowRecordModal(false)}>
+                キャンセル
+              </button>
+              <button
+                className="save-btn"
+                onClick={handleAddRecord}
+                disabled={!selectedProject || !newRecordContent.trim()}
+              >
+                保存
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecordCalendarPage;

--- a/frontend/src/pages/RecordCalendarPage.tsx
+++ b/frontend/src/pages/RecordCalendarPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Record, ResearchProject, Schedule } from '../types';
 import '../styles/RecordCalendar.css';
 import '../styles/Common.css';
@@ -83,7 +83,7 @@ const RecordCalendarPage: React.FC<RecordCalendarPageProps> = ({
     return days;
   };
 
-  const calendarDays = generateCalendarDays();
+  const calendarDays = useMemo(() => generateCalendarDays(), [currentDate, records, schedules]);
 
   // 前月・次月の移動
   const navigateMonth = (direction: 'prev' | 'next') => {

--- a/frontend/src/styles/ActiveProject.css
+++ b/frontend/src/styles/ActiveProject.css
@@ -88,23 +88,25 @@
   transition: width 0.3s ease;
 }
 
-.active-project-content {
-  display: flex !important;
-  flex-direction: row !important;
-  gap: 30px !important;
-  margin-top: 20px !important;
-  width: 100% !important;
-  align-items: flex-start !important;
+/* ActiveProjectページ専用のコンテンツレイアウト */
+.page-container .active-project-content {
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  margin-top: 20px;
+  width: 100%;
+  align-items: flex-start;
 }
 
-.steps-timeline {
-  flex: 1 !important;
+/* タイムラインセクション */
+.page-container .active-project-content .steps-timeline {
+  flex: 1;
   background: white;
   padding: 25px;
   border-radius: 15px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  height: fit-content !important;
-  min-width: 300px !important;
+  height: fit-content;
+  min-width: 300px;
 }
 
 .steps-timeline h2 {
@@ -167,8 +169,9 @@
   color: #666;
 }
 
-.current-step-detail {
-  flex: 2 !important;
+/* 現在のステップの詳細セクション */
+.page-container .active-project-content .current-step-detail {
+  flex: 2;
   background: white;
   border-radius: 15px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -306,14 +309,15 @@
 
 /* レスポンシブデザイン */
 @media (max-width: 768px) {
-  .active-project-content {
-    flex-direction: column !important;
-    gap: 20px !important;
+  .page-container .active-project-content {
+    flex-direction: column;
+    gap: 20px;
   }
 
-  .steps-timeline, .current-step-detail {
-    flex: none !important;
-    min-width: auto !important;
+  .page-container .active-project-content .steps-timeline,
+  .page-container .active-project-content .current-step-detail {
+    flex: none;
+    min-width: auto;
   }
 
   .project-header {

--- a/frontend/src/styles/ActiveProject.css
+++ b/frontend/src/styles/ActiveProject.css
@@ -88,7 +88,7 @@
   transition: width 0.3s ease;
 }
 
-.content-section {
+.active-project-content {
   display: flex !important;
   flex-direction: row !important;
   gap: 30px !important;
@@ -306,7 +306,7 @@
 
 /* レスポンシブデザイン */
 @media (max-width: 768px) {
-  .content-section {
+  .active-project-content {
     flex-direction: column !important;
     gap: 20px !important;
   }

--- a/frontend/src/styles/ActiveProject.css
+++ b/frontend/src/styles/ActiveProject.css
@@ -89,18 +89,22 @@
 }
 
 .content-section {
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 30px;
-  margin-top: 20px;
+  display: flex !important;
+  flex-direction: row !important;
+  gap: 30px !important;
+  margin-top: 20px !important;
+  width: 100% !important;
+  align-items: flex-start !important;
 }
 
 .steps-timeline {
+  flex: 1 !important;
   background: white;
   padding: 25px;
   border-radius: 15px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  height: fit-content;
+  height: fit-content !important;
+  min-width: 300px !important;
 }
 
 .steps-timeline h2 {
@@ -164,6 +168,7 @@
 }
 
 .current-step-detail {
+  flex: 2 !important;
   background: white;
   border-radius: 15px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -302,8 +307,13 @@
 /* レスポンシブデザイン */
 @media (max-width: 768px) {
   .content-section {
-    grid-template-columns: 1fr;
-    gap: 20px;
+    flex-direction: column !important;
+    gap: 20px !important;
+  }
+
+  .steps-timeline, .current-step-detail {
+    flex: none !important;
+    min-width: auto !important;
   }
 
   .project-header {

--- a/frontend/src/styles/RecordCalendar.css
+++ b/frontend/src/styles/RecordCalendar.css
@@ -1,0 +1,537 @@
+.record-calendar-page {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: calc(100vh - 80px);
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 30px;
+  gap: 15px;
+}
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 15px 30px;
+  background: #F5F5F5;
+  color: #666;
+  border: 2px solid #E0E0E0;
+  border-radius: 15px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.back-btn:hover {
+  background: #EEEEEE;
+  border-color: #BDBDBD;
+  transform: translateY(-2px);
+}
+
+.page-title {
+  font-size: 28px;
+  color: #333;
+  margin: 0;
+  font-weight: 600;
+}
+
+.calendar-container {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  padding: 30px;
+  margin-bottom: 30px;
+}
+
+/* カレンダーヘッダー */
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.nav-btn {
+  background: #f8f9fa;
+  border: 2px solid #e9ecef;
+  border-radius: 12px;
+  width: 50px;
+  height: 50px;
+  font-size: 24px;
+  color: #495057;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-btn:hover {
+  background: #e9ecef;
+  border-color: #dee2e6;
+}
+
+.month-title {
+  font-size: 24px;
+  color: #333;
+  margin: 0;
+  font-weight: 600;
+}
+
+/* 曜日ヘッダー */
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  margin-bottom: 10px;
+}
+
+.weekday-header {
+  padding: 15px 10px;
+  text-align: center;
+  font-weight: 600;
+  color: #666;
+  background: #f8f9fa;
+  border-radius: 8px 8px 0 0;
+}
+
+/* カレンダーグリッド */
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  background: #e9ecef;
+  border-radius: 0 0 12px 12px;
+  overflow: hidden;
+}
+
+.calendar-day {
+  background: white;
+  min-height: 100px;
+  padding: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-day:hover {
+  background: #f8f9fa;
+}
+
+.calendar-day.other-month {
+  background: #f8f9fa;
+  color: #aaa;
+}
+
+.calendar-day.other-month:hover {
+  background: #f0f0f0;
+}
+
+.calendar-day.selected {
+  background: #e3f2fd;
+  border: 2px solid #2196f3;
+}
+
+.calendar-day.has-actions {
+  background: linear-gradient(135deg, #fff3cd 0%, #ffffff 50%);
+}
+
+.calendar-day.has-observations {
+  background: linear-gradient(135deg, #d1ecf1 0%, #ffffff 50%);
+}
+
+.calendar-day.has-actions.has-observations {
+  background: linear-gradient(135deg, #d1ecf1 0%, #fff3cd 50%, #ffffff 100%);
+}
+
+.day-number {
+  font-weight: 600;
+  font-size: 16px;
+  margin-bottom: 5px;
+}
+
+.activity-indicators {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.observation-dot {
+  font-size: 12px;
+}
+
+.action-count {
+  background: #ffc107;
+  color: #333;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 12px;
+  min-width: 20px;
+  text-align: center;
+}
+
+/* 凡例 */
+.calendar-legend {
+  display: flex;
+  gap: 20px;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid #e9ecef;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #666;
+}
+
+.legend-color {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+}
+
+.has-actions-color {
+  background: linear-gradient(135deg, #fff3cd 0%, #ffffff 100%);
+  border: 1px solid #ffc107;
+}
+
+.legend-icon {
+  font-size: 16px;
+}
+
+/* 選択した日の詳細 */
+.selected-date-details {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  padding: 30px;
+}
+
+.details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.details-header h3 {
+  margin: 0;
+  font-size: 20px;
+  color: #333;
+}
+
+.add-record-btn {
+  background: #4caf50;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.add-record-btn:hover {
+  background: #45a049;
+}
+
+.no-records {
+  color: #666;
+  font-style: italic;
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.records-list {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.record-item {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.record-item:hover {
+  background: #e9ecef;
+  transform: translateY(-1px);
+}
+
+.record-type-icon {
+  font-size: 24px;
+  min-width: 40px;
+  text-align: center;
+}
+
+.record-content {
+  flex: 1;
+}
+
+.record-title {
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 5px;
+}
+
+.record-preview {
+  color: #666;
+  font-size: 14px;
+}
+
+.record-time {
+  color: #888;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.schedule-item {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 15px;
+  background: #f8f9fa;
+  border-radius: 12px;
+}
+
+.schedule-item.completed {
+  background: #e8f5e8;
+}
+
+.schedule-icon {
+  font-size: 20px;
+  min-width: 40px;
+  text-align: center;
+}
+
+.schedule-content {
+  flex: 1;
+}
+
+.schedule-title {
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 5px;
+}
+
+.schedule-description {
+  color: #666;
+  font-size: 14px;
+}
+
+/* モーダル */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.record-modal {
+  background: white;
+  border-radius: 16px;
+  width: 90%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 30px;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 20px;
+  color: #333;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #666;
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+}
+
+.close-btn:hover {
+  background: #f0f0f0;
+}
+
+.modal-body {
+  padding: 30px;
+}
+
+.form-group {
+  margin-bottom: 25px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+  color: #333;
+}
+
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: 12px;
+  border: 2px solid #e9ecef;
+  border-radius: 8px;
+  font-size: 14px;
+  transition: border-color 0.2s;
+}
+
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #2196f3;
+}
+
+.record-type-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.type-btn {
+  padding: 10px 15px;
+  border: 2px solid #e9ecef;
+  background: white;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 14px;
+}
+
+.type-btn:hover {
+  border-color: #2196f3;
+}
+
+.type-btn.active {
+  background: #2196f3;
+  color: white;
+  border-color: #2196f3;
+}
+
+.modal-footer {
+  padding: 20px 30px;
+  border-top: 1px solid #e9ecef;
+  display: flex;
+  gap: 15px;
+  justify-content: flex-end;
+}
+
+.cancel-btn,
+.save-btn {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.cancel-btn {
+  background: #f8f9fa;
+  color: #666;
+}
+
+.cancel-btn:hover {
+  background: #e9ecef;
+}
+
+.save-btn {
+  background: #4caf50;
+  color: white;
+}
+
+.save-btn:hover {
+  background: #45a049;
+}
+
+.save-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .record-calendar-page {
+    padding: 15px;
+  }
+
+  .calendar-container {
+    padding: 20px;
+  }
+
+  .calendar-day {
+    min-height: 80px;
+    padding: 5px;
+  }
+
+  .day-number {
+    font-size: 14px;
+  }
+
+  .page-title {
+    font-size: 24px;
+  }
+
+  .record-modal {
+    width: 95%;
+    margin: 10px;
+  }
+
+  .modal-body {
+    padding: 20px;
+  }
+
+  .record-type-buttons {
+    flex-direction: column;
+  }
+
+  .details-header {
+    flex-direction: column;
+    gap: 15px;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/utils/mockData.ts
+++ b/frontend/src/utils/mockData.ts
@@ -1,4 +1,4 @@
-import { ResearchProject, UserStats, Achievement } from '../types';
+import { ResearchProject, UserStats, Achievement, Record, Schedule } from '../types';
 
 // モックアクティブプロジェクト
 export const mockActiveProjects: ResearchProject[] = [
@@ -92,5 +92,111 @@ export const mockPastProjects: ResearchProject[] = [
     progressPercentage: 100,
     createdAt: '2024-07-15',
     updatedAt: '2024-08-03'
+  }
+];
+
+// 記録のモックデータ
+export const mockRecords: Record[] = [
+  {
+    id: 'record-1',
+    projectId: 'project-1',
+    recordType: 'observation',
+    title: '植物の成長観察',
+    content: '今日はアサガオの芽が1cm伸びていました。葉っぱも少し大きくなったように見えます。',
+    data: { height: 5.2, leafCount: 4 },
+    recordDate: '2024-12-10T14:30:00Z',
+    weatherInfo: { condition: '晴れ', temperature: 22 },
+    createdAt: '2024-12-10T14:30:00Z',
+    updatedAt: '2024-12-10T14:30:00Z'
+  },
+  {
+    id: 'record-2',
+    projectId: 'project-1',
+    recordType: 'observation',
+    title: '植物の成長観察',
+    content: 'アサガオの高さが6.5cmになりました。新しい葉っぱが出てきそうです。',
+    data: { height: 6.5, leafCount: 4 },
+    recordDate: '2024-12-11T15:00:00Z',
+    weatherInfo: { condition: '曇り', temperature: 18 },
+    createdAt: '2024-12-11T15:00:00Z',
+    updatedAt: '2024-12-11T15:00:00Z'
+  },
+  {
+    id: 'record-3',
+    projectId: 'past-project-1',
+    recordType: 'experiment',
+    title: '実験結果の記録',
+    content: '氷が完全に溶けるまでに35分かかりました。室温は24度でした。',
+    data: { meltingTime: 35, roomTemperature: 24 },
+    recordDate: '2024-12-09T13:20:00Z',
+    createdAt: '2024-12-09T13:20:00Z',
+    updatedAt: '2024-12-09T13:20:00Z'
+  },
+  {
+    id: 'record-4',
+    projectId: 'project-1',
+    recordType: 'note',
+    title: 'メモ',
+    content: '明日は雨の予報なので、植物を室内に入れるかどうか検討する必要がある。',
+    data: {},
+    recordDate: '2024-12-12T19:00:00Z',
+    createdAt: '2024-12-12T19:00:00Z',
+    updatedAt: '2024-12-12T19:00:00Z'
+  }
+];
+
+// スケジュールのモックデータ
+export const mockSchedules: Schedule[] = [
+  {
+    id: 'schedule-1',
+    projectId: 'project-1',
+    eventType: 'task',
+    title: '植物の水やり',
+    description: 'アサガオに水をあげましょう',
+    scheduledAt: '2024-12-10T08:00:00Z',
+    isCompleted: true,
+    reminderSent: true,
+    reminderSettings: {},
+    createdAt: '2024-12-10T07:00:00Z',
+    updatedAt: '2024-12-10T08:15:00Z'
+  },
+  {
+    id: 'schedule-2',
+    projectId: 'project-1',
+    eventType: 'observation',
+    title: '成長測定',
+    description: '植物の高さと葉っぱの数を測定する',
+    scheduledAt: '2024-12-11T15:00:00Z',
+    isCompleted: true,
+    reminderSent: true,
+    reminderSettings: {},
+    createdAt: '2024-12-10T15:00:00Z',
+    updatedAt: '2024-12-11T15:30:00Z'
+  },
+  {
+    id: 'schedule-3',
+    projectId: 'past-project-2',
+    eventType: 'task',
+    title: '実験器具の準備',
+    description: '明日の実験のために器具を準備する',
+    scheduledAt: '2024-12-12T16:00:00Z',
+    isCompleted: false,
+    reminderSent: false,
+    reminderSettings: {},
+    createdAt: '2024-12-12T10:00:00Z',
+    updatedAt: '2024-12-12T10:00:00Z'
+  },
+  {
+    id: 'schedule-4',
+    projectId: 'project-1',
+    eventType: 'reminder',
+    title: '観察の時間',
+    description: '今日の植物観察を忘れずに',
+    scheduledAt: '2024-12-13T14:00:00Z',
+    isCompleted: false,
+    reminderSent: false,
+    reminderSettings: {},
+    createdAt: '2024-12-12T20:00:00Z',
+    updatedAt: '2024-12-12T20:00:00Z'
   }
 ];


### PR DESCRIPTION
このプルリクエストでは、「記録カレンダー」機能を新たに追加し、プロジェクトの記録やスケジュールを管理・可視化できるようにしました。また、これに伴い、コンテキスト、ルーティング、スタイルの必要な更新も行っています。主な変更点は以下の通りです。

### 記録カレンダー機能:

* **`RecordCalendarPage` コンポーネント**  
  カレンダー形式で記録とスケジュールを表示する新しいページを追加しました。ユーザーは月ごとの移動、特定日付の詳細確認、新規記録の追加が可能です。

* **ルーティングの更新**  
  新しいルート `/records` を追加し、`RecordCalendarPage` に遷移できるようにしました。

---

### コンテキストの更新:

* **`AppContext` の拡張**  
  `records` と `schedules` のサポートを追加しました。モックデータの初期化およびコンテキスト状態の管理も含まれています。  
  [[1]](diffhunk://#diff-9a7074b73f3536c8c22b6453abf134dd4d66fb87551489d4f98e5f2f85f9a265L2-R4)  
  [[2]](diffhunk://#diff-9a7074b73f3536c8c22b6453abf134dd4d66fb87551489d4f98e5f2f85f9a265R28-R31)  
  [[3]](diffhunk://#diff-9a7074b73f3536c8c22b6453abf134dd4d66fb87551489d4f98e5f2f85f9a265R79-R80)  
  [[4]](diffhunk://#diff-9a7074b73f3536c8c22b6453abf134dd4d66fb87551489d4f98e5f2f85f9a265R407-R408)

---

### モックデータの更新:

* **記録とスケジュールのモックデータ**  
  記録カレンダー機能の動作確認のため、記録およびスケジュールのモックデータを追加しました。

---

### スタイルの更新:

* **アクティブプロジェクトページのスタイル**  
  グリッドベースのレイアウトをフレックスボックスに置き換え、レイアウトの柔軟性とレスポンシブ性を向上させました。  
  [[1]](diffhunk://#diff-4f9d2f2402cda6e7612d308681cbacc5df86ed8660f6e6a34f717654eb6959dfL91-R107)  
  [[2]](diffhunk://#diff-4f9d2f2402cda6e7612d308681cbacc5df86ed8660f6e6a34f717654eb6959dfR171)  
  [[3]](diffhunk://#diff-4f9d2f2402cda6e7612d308681cbacc5df86ed8660f6e6a34f717654eb6959dfL304-R316)

---

### その他:

* **ナビゲーションロジックの更新**  
  `handleViewRecords` 関数を更新し、プレースホルダーのログ出力の代わりに `/records` ルートへ遷移するよう変更しました。
